### PR TITLE
Added Avro example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # akka-serialization-test
-Study on [akka-serialization][ser] using [Google Protocol Buffers][pb] and [Kryo][kryo].
+Study on [akka-serialization][ser] using [Google Protocol Buffers][pb], [Kryo][kryo] and [Avro][avro]
 
 # TL;DR
 Define domain command and events messages in the companion object of the `PersistentActor` using DDD concepts. 
@@ -82,6 +82,9 @@ extensions for the [Kryo][kryo] serialization library including serializers and 
 ## Kryo Akka Serialization
 [Chill][chill] provides a [Kryo Akka Serializer][chill-akka] out of the box.
 
+## Avro
+Avro serialization/deserialization is done using [avro4s][avro4s] project.
+
 Have fun!
 
 [akka]: http://akka.io/
@@ -94,3 +97,5 @@ Have fun!
 [chill]: https://github.com/twitter/chill
 [chill-akka]: https://github.com/twitter/chill#chill-akka
 [chill-maven-central]: http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.twitter%22%20AND%20a%3A%22chill-akka_2.11%22
+[avro]: https://avro.apache.org/
+[avro4s]: https://github.com/sksamuel/avro4s

--- a/build.sbt
+++ b/build.sbt
@@ -8,10 +8,12 @@ scalaVersion := "2.11.8"
 
 resolvers += Resolver.jcenterRepo
 
+
 libraryDependencies ++= {
   val akkaVersion = "2.4.7"
   val json4sVersion = "3.3.0"
   val akkaPersistenceInMemVersion = "1.2.15"
+  val avro4s = "1.4.3"
   Seq(
     "com.typesafe.akka" %% "akka-actor" % akkaVersion,
     "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
@@ -25,7 +27,9 @@ libraryDependencies ++= {
     "com.github.dnvriend" %% "akka-persistence-inmemory" % akkaPersistenceInMemVersion % Test,
     "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test,
     "org.scalatest" %% "scalatest" % "2.2.6" % Test,
-    "org.scalacheck" %% "scalacheck" % "1.12.5" % Test
+    "org.scalacheck" %% "scalacheck" % "1.12.5" % Test,
+    "com.sksamuel.avro4s" %% "avro4s-core" % avro4s,
+    "org.apache.avro" % "avro" % "1.7.7"
   )
 }
 

--- a/src/main/scala/com/github/dnvriend/domain/Music.scala
+++ b/src/main/scala/com/github/dnvriend/domain/Music.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dnvriend.domain
+
+import java.time.Duration
+
+import akka.actor.ActorLogging
+import akka.event.LoggingReceive
+import akka.persistence.PersistentActor
+
+object Music {
+
+  type Title = String
+  type Year = Int
+
+  final case class Song(title: Title, duration: Duration)
+
+  sealed trait AlbumEvent
+
+  final case class TitleChanged(title: Title) extends AlbumEvent
+
+  final case class YearChanged(year: Year) extends AlbumEvent
+
+  final case class SongAdded(song: Song) extends AlbumEvent
+
+  final case class SongRemoved(song: Song) extends AlbumEvent
+
+  sealed trait AlbumCommand
+
+  final case class ChangeAlbumTitle(title: Title) extends AlbumCommand
+
+  final case class ChangeAlbumYear(year: Year) extends AlbumCommand
+
+  final case class AddSong(song: Song) extends AlbumCommand
+
+  final case class RemoveSong(song: Song) extends AlbumCommand
+
+}
+
+class Album(val persistenceId: String) extends PersistentActor with ActorLogging {
+
+  import Music._
+
+  var title: Title = _
+  var year: Year = _
+  var songs: Set[Song] = Set[Song]()
+
+  override def receiveRecover: Receive = LoggingReceive {
+    case e: TitleChanged ⇒ handleEvent(e)
+    case e: YearChanged  ⇒ handleEvent(e)
+    case e: SongAdded    ⇒ handleEvent(e)
+    case e: SongRemoved  ⇒ handleEvent(e)
+  }
+
+  def handleEvent(event: TitleChanged): Unit = {
+    this.title = event.title
+    log.debug(s"[TitleChanged]: Album $persistenceId => title: $title, year: $year songs: $songs")
+  }
+
+  def handleEvent(event: YearChanged): Unit = {
+    this.year = event.year
+    log.debug(s"[YearChanged]: Album $persistenceId => title: $title, year: $year songs: $songs")
+  }
+
+  def handleEvent(event: SongAdded): Unit = {
+    this.songs = this.songs + event.song
+    log.debug(s"[SongAdded]: Album $persistenceId => title: $title, year: $year songs: $songs")
+  }
+
+  def handleEvent(event: SongRemoved): Unit = {
+    this.songs = this.songs - event.song
+    log.debug(s"[SongRemoved]: Album $persistenceId => title: $title, year: $year songs: $songs")
+  }
+
+  override def receiveCommand: Receive = LoggingReceive {
+    case ChangeAlbumTitle(newTitle) ⇒
+      persistAll(List(TitleChanged(newTitle)))(handleEvent)
+    case ChangeAlbumYear(newYear) ⇒
+      persistAll(List(YearChanged(newYear)))(handleEvent)
+    case AddSong(newSong) ⇒
+      persistAll(List(SongAdded(newSong)))(handleEvent)
+    case RemoveSong(oldSong) ⇒
+      persistAll(List(SongRemoved(oldSong)))(handleEvent)
+  }
+
+  override def postStop(): Unit = {
+    log.debug(s"Stopped $persistenceId")
+    super.postStop()
+  }
+}

--- a/src/main/scala/com/github/dnvriend/repository/AlbumRepository.scala
+++ b/src/main/scala/com/github/dnvriend/repository/AlbumRepository.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dnvriend.repository
+
+import akka.actor.{ Props, ActorRef, ActorSystem }
+import com.github.dnvriend.domain.Album
+
+object AlbumRepository {
+  def forId(id: String)(implicit system: ActorSystem): ActorRef =
+    system.actorOf(Props(new Album(id)), id)
+
+}

--- a/src/main/scala/com/github/dnvriend/serializer/avro/AvroSerializer.scala
+++ b/src/main/scala/com/github/dnvriend/serializer/avro/AvroSerializer.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dnvriend.serializer.avro
+
+import java.io.ByteArrayOutputStream
+
+import akka.serialization.SerializerWithStringManifest
+import com.github.dnvriend.domain.Music._
+import com.sksamuel.avro4s._
+
+import CustomMapping._
+
+abstract class AvroSerializer[T] extends SerializerWithStringManifest {
+  override def manifest(o: AnyRef): String = o.getClass.getName
+}
+
+class TitleChangedSerializer extends AvroSerializer[TitleChanged] {
+  override def identifier: Int = 100010
+  final val Manifest = classOf[TitleChanged].getName
+
+  override def toBinary(o: AnyRef): Array[Byte] = {
+    val output = new ByteArrayOutputStream
+    val avro = AvroOutputStream[TitleChanged](output)
+    avro.write(o.asInstanceOf[TitleChanged])
+    avro.close()
+    output.toByteArray
+  }
+
+  override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = {
+    if (Manifest == manifest) {
+
+      val is = AvroInputStream[TitleChanged](bytes)
+      val events = is.iterator.toList
+      is.close()
+
+      events(0)
+
+    } else throw new IllegalArgumentException(s"Unable to handle manifest $manifest, required $Manifest")
+  }
+}
+
+class YearChangedSerializer extends AvroSerializer[YearChanged] {
+  override def identifier: Int = 100011
+  final val Manifest = classOf[YearChanged].getName
+
+  override def toBinary(o: AnyRef): Array[Byte] = {
+    val output = new ByteArrayOutputStream
+    val avro = AvroOutputStream[YearChanged](output)
+    avro.write(o.asInstanceOf[YearChanged])
+    avro.close()
+    output.toByteArray
+  }
+
+  override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = {
+    if (Manifest == manifest) {
+
+      val is = AvroInputStream[YearChanged](bytes)
+      val events = is.iterator.toList
+      is.close()
+
+      events(0)
+
+    } else throw new IllegalArgumentException(s"Unable to handle manifest $manifest, required $Manifest")
+  }
+}
+
+class SongAddedSerializer extends AvroSerializer[SongAdded] {
+  override def identifier: Int = 100012
+  final val Manifest = classOf[SongAdded].getName
+
+  override def toBinary(o: AnyRef): Array[Byte] = {
+    val output = new ByteArrayOutputStream
+    val avro = AvroOutputStream[SongAdded](output)
+    avro.write(o.asInstanceOf[SongAdded])
+    avro.close()
+    output.toByteArray
+  }
+
+  override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = {
+    if (Manifest == manifest) {
+
+      val is = AvroInputStream[SongAdded](bytes)
+      val events = is.iterator.toList
+      is.close()
+
+      events(0)
+
+    } else throw new IllegalArgumentException(s"Unable to handle manifest $manifest, required $Manifest")
+  }
+}
+
+class SongRemovedSerializer extends AvroSerializer[SongRemoved] {
+  override def identifier: Int = 100013
+  final val Manifest = classOf[SongRemoved].getName
+
+  override def toBinary(o: AnyRef): Array[Byte] = {
+    val output = new ByteArrayOutputStream
+    val avro = AvroOutputStream[SongRemoved](output)
+    avro.write(o.asInstanceOf[SongRemoved])
+    avro.close()
+    output.toByteArray
+  }
+
+  override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = {
+    if (Manifest == manifest) {
+
+      val is = AvroInputStream[SongRemoved](bytes)
+      val events = is.iterator.toList
+      is.close()
+
+      events(0)
+
+    } else throw new IllegalArgumentException(s"Unable to handle manifest $manifest, required $Manifest")
+  }
+}
+

--- a/src/main/scala/com/github/dnvriend/serializer/avro/CustomMapping.scala
+++ b/src/main/scala/com/github/dnvriend/serializer/avro/CustomMapping.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dnvriend.serializer.avro
+
+import java.time.Duration
+
+import com.sksamuel.avro4s.{ FromValue, ToValue, ToSchema }
+import org.apache.avro.Schema
+import org.apache.avro.Schema.Field
+
+object CustomMapping {
+
+  implicit object DurationToSchema extends ToSchema[Duration] {
+    override def apply(): Schema = Schema.create(Schema.Type.STRING)
+  }
+
+  implicit object DurationToValue extends ToValue[Duration] {
+    override def apply(value: Duration): String = value.toMillis.toString
+  }
+
+  implicit object DurationFromValue extends FromValue[Duration] {
+    override def apply(value: Any, field: Field): Duration = Duration.ofMillis(value.toString.toInt)
+  }
+
+}

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -38,6 +38,12 @@ akka {
       personCreated = "com.github.dnvriend.serializer.protobuf.NameRegisteredSerializer"
       nameChanged = "com.github.dnvriend.serializer.protobuf.NameChangedSerializer"
       surnameChanged = "com.github.dnvriend.serializer.protobuf.SurnameChangedSerializer"
+      titleChanged = "com.github.dnvriend.serializer.avro.TitleChangedSerializer"
+      yearChanged = "com.github.dnvriend.serializer.avro.YearChangedSerializer"
+      songAdded = "com.github.dnvriend.serializer.avro.SongAddedSerializer"
+      songRemoved = "com.github.dnvriend.serializer.avro.SongRemovedSerializer"
+
+
     }
 
     serialization-bindings {
@@ -46,6 +52,12 @@ akka {
       "com.github.dnvriend.domain.Person$NameRegistered" = personCreated
       "com.github.dnvriend.domain.Person$NameChanged" = nameChanged
       "com.github.dnvriend.domain.Person$SurnameChanged" = surnameChanged
+
+
+      "com.github.dnvriend.domain.Music$TitleChanged" = titleChanged
+      "com.github.dnvriend.domain.Music$YearChanged" = yearChanged
+      "com.github.dnvriend.domain.Music$SongAdded" = songAdded
+      "com.github.dnvriend.domain.Music$SongRemoved" = songRemoved
     }
   }
 

--- a/src/test/scala/com/github/dnvriend/domain/AlbumTest.scala
+++ b/src/test/scala/com/github/dnvriend/domain/AlbumTest.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dnvriend.domain
+
+import java.time.Duration
+
+import akka.persistence.inmemory.query.journal.scaladsl.InMemoryReadJournal
+import akka.persistence.query.PersistenceQuery
+import akka.stream.testkit.scaladsl.TestSink
+import com.github.dnvriend.TestSpec
+import com.github.dnvriend.domain.Music._
+import com.github.dnvriend.repository.AlbumRepository
+
+class AlbumTest extends TestSpec {
+  lazy val queries = PersistenceQuery(system).readJournalFor[InMemoryReadJournal](InMemoryReadJournal.Identifier)
+
+  def eventsForPersistenceIdSource(id: String) =
+    queries.currentEventsByPersistenceId(id, 0L, Long.MaxValue).map(_.event)
+
+  "Album" should "register a title" in {
+    val album = AlbumRepository.forId("album-1")
+    val xs = List(ChangeAlbumTitle("Dark side of the Moon"))
+    xs foreach (album ! _)
+
+    eventually {
+      eventsForPersistenceIdSource("album-1")
+        .runWith(TestSink.probe[Any])
+        .request(Int.MaxValue)
+        .expectNextN(xs.map(cmd ⇒ TitleChanged(cmd.title)))
+        .expectComplete()
+    }
+
+    cleanup(album)
+  }
+
+  it should "update its title and year and songs" in {
+    val album = AlbumRepository.forId("album-2")
+    val xs = List(
+      ChangeAlbumTitle("Dark side of the Moon"),
+      ChangeAlbumYear(1973),
+      AddSong(Song("Money", Duration.ofSeconds(390))),
+      AddSong(Song("Redemption Song", Duration.ofSeconds(227))),
+      RemoveSong(Song("Redemption Song", Duration.ofSeconds(227)))
+    )
+
+    val expectedEvents = xs.map {
+      case ChangeAlbumTitle(title) ⇒ TitleChanged(title)
+      case ChangeAlbumYear(year)   ⇒ YearChanged(year)
+      case AddSong(song)           ⇒ SongAdded(song)
+      case RemoveSong(song)        ⇒ SongRemoved(song)
+    }
+
+    xs foreach (album ! _)
+    eventually {
+      eventsForPersistenceIdSource("album-2")
+        .runWith(TestSink.probe[Any])
+        .request(Int.MaxValue)
+        .expectNextN(
+          expectedEvents
+        )
+        .expectComplete()
+    }
+  }
+}

--- a/src/test/scala/com/github/dnvriend/serializer/avro4s/SongAddedSerializerTest.scala
+++ b/src/test/scala/com/github/dnvriend/serializer/avro4s/SongAddedSerializerTest.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dnvriend.serializer.avro4s
+
+import java.time.Duration
+
+import com.github.dnvriend.TestSpec
+import com.github.dnvriend.domain.Music.{ SongAdded, Song }
+
+class SongAddedSerializerTest extends TestSpec {
+  "SongAdded" should "be serialized to a byte array" in {
+    val obj = SongAdded(Song("Money", Duration.ofSeconds(390)))
+    val serializer = serialization.findSerializerFor(obj)
+    val bytes: Array[Byte] = serializer.toBinary(obj)
+    bytes.toList should not be 'empty
+  }
+
+  it should "turn a byte array back into an object" in {
+    val obj = SongAdded(Song("Money", Duration.ofSeconds(390)))
+    val serializer = serialization.findSerializerFor(obj)
+    val bytes = serializer.toBinary(obj)
+
+    serializer.fromBinary(bytes, Option(obj.getClass)) should matchPattern {
+      case SongAdded(Song("Money", x)) if (x.isInstanceOf[Duration]) ⇒
+    }
+  }
+}

--- a/src/test/scala/com/github/dnvriend/serializer/avro4s/SongRemovedSerializerTest.scala
+++ b/src/test/scala/com/github/dnvriend/serializer/avro4s/SongRemovedSerializerTest.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dnvriend.serializer.avro4s
+
+import java.time.Duration
+
+import com.github.dnvriend.TestSpec
+import com.github.dnvriend.domain.Music.{Song, SongRemoved}
+
+class SongRemovedSerializerTest extends TestSpec {
+  "SongRemoved" should "be serialized to a byte array" in {
+    val obj = SongRemoved(Song("Money", Duration.ofSeconds(390)))
+    val serializer = serialization.findSerializerFor(obj)
+    val bytes: Array[Byte] = serializer.toBinary(obj)
+    bytes.toList should not be 'empty
+  }
+
+  it should "turn a byte array back into an object" in {
+    val obj = SongRemoved(Song("Money", Duration.ofSeconds(390)))
+    val serializer = serialization.findSerializerFor(obj)
+    val bytes = serializer.toBinary(obj)
+
+    serializer.fromBinary(bytes, Option(obj.getClass)) should matchPattern {
+      case SongRemoved(Song("Money", x)) if (x.isInstanceOf[Duration]) ⇒
+    }
+  }
+}

--- a/src/test/scala/com/github/dnvriend/serializer/avro4s/TitleChangedSerializerTest.scala
+++ b/src/test/scala/com/github/dnvriend/serializer/avro4s/TitleChangedSerializerTest.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dnvriend.serializer.avro4s
+
+import com.github.dnvriend.TestSpec
+import com.github.dnvriend.domain.Music.TitleChanged
+
+class TitleChangedSerializerTest extends TestSpec {
+  "TitleChanged" should "be serialized to a byte array" in {
+    val obj = TitleChanged("Foo")
+    val serializer = serialization.findSerializerFor(obj)
+    val bytes: Array[Byte] = serializer.toBinary(obj)
+    bytes.toList should not be 'empty
+  }
+
+  it should "turn a byte array back into an object" in {
+    val obj = TitleChanged("Foo")
+    val serializer = serialization.findSerializerFor(obj)
+    val bytes = serializer.toBinary(obj)
+
+    serializer.fromBinary(bytes, Option(obj.getClass)) should matchPattern {
+      case TitleChanged("Foo") ⇒
+    }
+  }
+}

--- a/src/test/scala/com/github/dnvriend/serializer/avro4s/YearChangedSerializerTest.scala
+++ b/src/test/scala/com/github/dnvriend/serializer/avro4s/YearChangedSerializerTest.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Dennis Vriend
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.dnvriend.serializer.avro4s
+
+import com.github.dnvriend.TestSpec
+import com.github.dnvriend.domain.Music.YearChanged
+
+class YearChangedSerializerTest extends TestSpec {
+  "YearChanged" should "be serialized to a byte array" in {
+    val obj = YearChanged(1980)
+    val serializer = serialization.findSerializerFor(obj)
+    val bytes: Array[Byte] = serializer.toBinary(obj)
+    bytes.toList should not be 'empty
+  }
+
+  it should "turn a byte array back into an object" in {
+    val obj = YearChanged(1980)
+    val serializer = serialization.findSerializerFor(obj)
+    val bytes = serializer.toBinary(obj)
+
+    serializer.fromBinary(bytes, Option(obj.getClass)) should matchPattern {
+      case YearChanged(1980) ⇒
+    }
+  }
+}


### PR DESCRIPTION
Hi,

I've added an Avro serialization example to your repo. This [documentation](http://doc.akka.io/docs/akka/current/scala/persistence-schema-evolution.html) names Avro as possible solution for IDL serialization, however it does not provide an example (and I did not find one). If you agree I would add my example to yours. I've tried to use the same style you used, there are just little differences on the tests. I did not use generators). 

I've tried to reuse code in serializers but, since avro4s uses macro, it did not work.
The Readme just names Avro as third format in the examples. 
